### PR TITLE
fix: remove section focus to prevent focus issues

### DIFF
--- a/BCC Media tvOS/Components/Page/PageView.swift
+++ b/BCC Media tvOS/Components/Page/PageView.swift
@@ -44,7 +44,7 @@ struct PageView: View {
         ScrollView(.vertical) {
             LazyVStack(alignment: .leading) {
                 ForEach(page.sections.items.indices, id: \.self) { index in
-                    SectionView(page, index, clickItem: clickItem).focusSection()
+                    SectionView(page, index, clickItem: clickItem)
                 }
             }
             .padding(100)

--- a/BCC Media tvOS/Components/Sections/FeaturedSection.swift
+++ b/BCC Media tvOS/Components/Sections/FeaturedSection.swift
@@ -65,15 +65,13 @@ struct FeaturedSection: View {
         self.clickItem = clickItem
     }
 
-    @FocusState var liveFocused: Bool
-
     var body: some View {
         VStack {
             ScrollView(.horizontal) {
                 LazyHStack(alignment: .top, spacing: 20) {
-                    ForEach(items.indices, id: \.self) { index in
-                        FeaturedCard(item: items[index]) {
-                            await clickItem(items[index])
+                    ForEach(items) { item in
+                        FeaturedCard(item: item) {
+                            await clickItem(item)
                         }
                     }.frame(width: 800)
                 }.padding(100)


### PR DESCRIPTION
There basically was a race condition where both the featured section and its items tried to focus on themselves, causing some weird issues